### PR TITLE
Update license to match the PDF.js license

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Embed PDF.js viewer into your angular application",
   "version": "1.0.0",
   "dependencies": {},
-  "license": "Apache",
+  "license": "Apache-2.0",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-replace": "^0.10.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Embed PDF.js viewer into your angular application",
   "version": "1.0.0",
   "dependencies": {},
-  "license": "proprietary",
+  "license": "Apache",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-replace": "^0.10.2"


### PR DESCRIPTION
Update to match the [PDF.js](https://mozilla.github.io/pdf.js/) license - Apache.
